### PR TITLE
Handle empty backtest positions gracefully

### DIFF
--- a/pipeline/backtest.py
+++ b/pipeline/backtest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict
 
-import numpy as np
+import math
 import pandas as pd
 
 
@@ -24,6 +24,13 @@ def long_short_backtest(
         pos.loc[long_assets] = 1.0 / k
         pos.loc[short_assets] = -1.0 / k
         positions.append(pos)
+    if not positions:
+        return {
+            "mean_daily_net": 0.0,
+            "sharpe_net_annual": 0.0,
+            "turnover_mean": 0.0,
+        }
+
     pos = pd.concat(positions, axis=0).sort_index()
 
     prev_pos = pos.groupby(level=0).shift(1).fillna(0.0)
@@ -34,7 +41,7 @@ def long_short_backtest(
     pnl_net = pnl_gross - costs
     sharpe = 0.0
     if pnl_net.std() > 0:
-        sharpe = pnl_net.mean() / pnl_net.std() * np.sqrt(252)
+        sharpe = pnl_net.mean() / pnl_net.std() * math.sqrt(252)
     return {
         "mean_daily_net": float(pnl_net.mean()),
         "sharpe_net_annual": float(sharpe),

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+from pipeline.backtest import long_short_backtest
+
+
+def test_long_short_backtest_handles_empty_positions():
+    idx_scores = pd.MultiIndex.from_tuples(
+        [("A", pd.Timestamp("2020-01-01"))], names=["asset", "date"]
+    )
+    idx_returns = pd.MultiIndex.from_tuples(
+        [("B", pd.Timestamp("2020-01-02"))], names=["asset", "date"]
+    )
+
+    scores = pd.Series(float("nan"), index=idx_scores)
+    future_returns = pd.Series(float("nan"), index=idx_returns)
+
+    result = long_short_backtest(scores, future_returns)
+
+    assert result == {
+        "mean_daily_net": 0.0,
+        "sharpe_net_annual": 0.0,
+        "turnover_mean": 0.0,
+    }


### PR DESCRIPTION
## Summary
- return default zero metrics when `long_short_backtest` cannot form any positions
- guard Sharpe and turnover calculations while removing the NumPy dependency
- add a regression test covering misaligned or missing inputs

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68de1f064c54832bb3e368c67c46b43e