### PR TITLE
Fix MAE inference batching and add CPU smoke test

### DIFF
--- a/pipeline/ssl.py
+++ b/pipeline/ssl.py
@@ -101,9 +101,11 @@ def train_mae1d(
     model.eval()
     embeddings: List[np.ndarray] = []
     with torch.no_grad():
-        tensor = torch.from_numpy(sequences.astype(np.float32)).to(device)
-        for start in range(0, len(tensor), 1024):
-            emb, _ = model(tensor[start : start + 1024])
+        tensor = torch.from_numpy(sequences.astype(np.float32))
+        inference_loader = DataLoader(tensor, batch_size=1024, shuffle=False)
+        for batch in inference_loader:
+            batch = batch.to(device)
+            emb, _ = model(batch)
             embeddings.append(emb.cpu().numpy())
     stacked = np.vstack(embeddings)
     return model, stacked

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,12 +1,24 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
 import pytest
 
-torch = pytest.importorskip("torch")
-np = pytest.importorskip("numpy")
 
-from pipeline.ssl import train_mae1d
+def _load_train_mae1d():
+    spec = spec_from_file_location(
+        "pipeline.ssl", Path(__file__).resolve().parents[1] / "pipeline" / "ssl.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.train_mae1d
 
 
 def test_train_mae1d_cpu_handles_large_batches():
+    torch = pytest.importorskip("torch", reason="Requires torch for SSL training test")
+    np = pytest.importorskip("numpy", reason="Requires numpy for SSL training test")
+
+    train_mae1d = _load_train_mae1d()
     torch.manual_seed(0)
     np.random.seed(0)
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,5 +1,7 @@
-import numpy as np
-import torch
+import pytest
+
+torch = pytest.importorskip("torch")
+np = pytest.importorskip("numpy")
 
 from pipeline.ssl import train_mae1d
 

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,0 +1,28 @@
+import numpy as np
+import torch
+
+from pipeline.ssl import train_mae1d
+
+
+def test_train_mae1d_cpu_handles_large_batches():
+    torch.manual_seed(0)
+    np.random.seed(0)
+
+    # Large enough to require multiple inference batches while remaining quick to train.
+    sequences = np.random.randn(2048, 3, 64).astype(np.float32)
+
+    model, embeddings = train_mae1d(
+        sequences,
+        epochs=1,
+        batch_size=256,
+        lr=1e-3,
+        mask_ratio=0.2,
+        mask_len=3,
+        device="cpu",
+    )
+
+    assert next(model.parameters()).device.type == "cpu"
+    assert embeddings.shape[0] == sequences.shape[0]
+    # Embeddings should reflect the model head size (default hidden width).
+    assert embeddings.shape[1] == 64
+    assert embeddings.dtype == np.float32


### PR DESCRIPTION
## Summary
- update MAE inference to keep the full sequence tensor on CPU and only move mini-batches to the accelerator
- add a smoke test that exercises CPU-only MAE training/inference on a large synthetic dataset

## Testing
- pytest *(fails: numpy dependency is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1f071fac832bbbd524e27fac9b3f