### PR TITLE
Handle partial batches in MAE training loop

### DIFF
--- a/pipeline/ssl.py
+++ b/pipeline/ssl.py
@@ -78,25 +78,26 @@ def train_mae1d(
 ) -> Tuple[MAE1D, np.ndarray]:
     device = device or ("cuda" if torch.cuda.is_available() else "cpu")
     dataset = MaskedAEDataset(sequences, mask_ratio=mask_ratio, mask_len=mask_len)
-    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=True)
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True, drop_last=False)
 
     model = MAE1D(in_channels=sequences.shape[1]).to(device)
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
     mse = nn.MSELoss(reduction="none")
 
     model.train()
-    for _ in range(epochs):
-        for masked, original, mask in loader:
-            masked = masked.to(device)
-            original = original.to(device)
-            mask = mask.to(device)
-            _, reconstruction = model(masked)
-            mask_expanded = mask.unsqueeze(1).expand_as(reconstruction)
-            loss = mse(reconstruction, original)
-            loss = (loss * mask_expanded).sum() / (mask_expanded.sum() + 1e-9)
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
+    if len(loader) > 0:
+        for _ in range(epochs):
+            for masked, original, mask in loader:
+                masked = masked.to(device)
+                original = original.to(device)
+                mask = mask.to(device)
+                _, reconstruction = model(masked)
+                mask_expanded = mask.unsqueeze(1).expand_as(reconstruction)
+                loss = mse(reconstruction, original)
+                loss = (loss * mask_expanded).sum() / (mask_expanded.sum() + 1e-9)
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
 
     model.eval()
     embeddings: List[np.ndarray] = []

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from pipeline.ssl import train_mae1d
+
+
+def test_train_mae1d_handles_partial_batch():
+    sequences = np.random.randn(4, 3, 5).astype(np.float32)
+    batch_size = 8
+
+    with patch.object(torch.optim.Adam, "step", wraps=torch.optim.Adam.step) as mock_step:
+        train_mae1d(sequences, epochs=1, batch_size=batch_size)
+
+    assert mock_step.call_count >= 1


### PR DESCRIPTION
## Summary
- allow the MAE training dataloader to keep partial batches and skip the optimization loop when no batches are available
- add a regression test to ensure partial batches still trigger optimizer steps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de1f072224832b95738927cda4ae00